### PR TITLE
issue #24: watch中に新規ファイルを作成しても対象にならない問題の修正

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,10 +16,10 @@ argv.forEach((item,i)=>{
  * 環境設定
  */
 const CONFIG_PATH = {
-  src     : './src/',
-  release : './release/',
-  cms     : './cms/',
-  php     : './php/'
+  src     : 'src/',
+  release : 'release/',
+  cms     : 'cms/',
+  php     : 'php/'
 };
 const CONFIG = {
   outputDirectory: {


### PR DESCRIPTION
issue#24につきまして、
srcの `./` を削除をしましたら。

watch中に新規ファイルを追加しましても、
正常に読み込みました。